### PR TITLE
Support Enlighten 4.1.6 revision codes

### DIFF
--- a/usb/wasatchConfig.py
+++ b/usb/wasatchConfig.py
@@ -66,6 +66,14 @@ class VirtualDevice(Ignore):
         if dev_handle == 0xc0 and bmRequestType == 0xff and bRequest == 0x3 and wValue == 0x0 and wIndex == 0x40 and self.idProduct == 0x1000:
             return [0x00, 0x04]
 
+        # REQUEST REVISION CODE
+        if dev_handle == 0xc0 and bmRequestType == 0xc0 and bRequest == 0x0 and wValue == 0x0 and wIndex == 0x40:
+            return [0x00, 0x00]
+
+        # REQUEST FPGA REVISION
+        if dev_handle == 0xc0 and bmRequestType == 0xb4 and bRequest == 0x0 and wValue == 0x0 and wIndex == 0x07:
+            return [0x00, 0x00]
+
         # log unhandled ctrl messages 
         def display(k):
             if type(k) == int:

--- a/usb/wasatchConfig.py
+++ b/usb/wasatchConfig.py
@@ -49,29 +49,29 @@ class VirtualDevice(Ignore):
 
         self.eeprom.generate_write_buffers()
 
-    def ctrl_transfer(self, dev_handle, bmRequestType, bRequest, wValue=0, wIndex=0, data_or_wLength = None, timeout = None):
+    def ctrl_transfer(self, bmRequestType, bRequest, wValue=0, wIndex=0, data_or_wLength = None, timeout = None):
         """ Here we pretend to be the device firmware """
 
         # REQUEST EEPROM
-        if dev_handle == 0xc0 and bmRequestType == 0xff and bRequest == 0x1 and wIndex == 0x40:
+        if bmRequestType == 0xc0 and bRequest == 0xff and wValue == 0x1 and data_or_wLength == 0x40:
             buf = self.eeprom.write_buffers[self._eeprom_page]
             self._eeprom_page += 1
             return buf
 
         # REQUEST FPGA COMPILATION OPTIONS
-        if dev_handle == 0xc0 and bmRequestType == 0xff and bRequest == 0x4 and wIndex == 0x40:
+        if bmRequestType == 0xc0 and bRequest == 0xff and wValue == 0x4 and data_or_wLength == 0x40:
             return [0xFF, 0xFF]
 
         # REQUEST LINE LENGTH (pid=0x1000)
-        if dev_handle == 0xc0 and bmRequestType == 0xff and bRequest == 0x3 and wValue == 0x0 and wIndex == 0x40 and self.idProduct == 0x1000:
+        if bmRequestType == 0xc0 and bRequest == 0xff and wValue == 0x3 and wIndex == 0x0 and data_or_wLength == 0x40 and self.idProduct == 0x1000:
             return [0x00, 0x04]
 
         # REQUEST REVISION CODE
-        if dev_handle == 0xc0 and bmRequestType == 0xc0 and bRequest == 0x0 and wValue == 0x0 and wIndex == 0x40:
+        if bmRequestType == 0xc0 and bRequest == 0xc0 and wValue == 0x0 and wIndex == 0x0 and data_or_wLength == 0x40:
             return [0x00, 0x00]
 
         # REQUEST FPGA REVISION
-        if dev_handle == 0xc0 and bmRequestType == 0xb4 and bRequest == 0x0 and wValue == 0x0 and wIndex == 0x07:
+        if bmRequestType == 0xc0 and bRequest == 0xb4 and wValue == 0x0 and wIndex == 0x0 and data_or_wLength == 0x07:
             return [0x00, 0x00]
 
         # log unhandled ctrl messages 
@@ -82,7 +82,7 @@ class VirtualDevice(Ignore):
                 return None
             else:
                 return str(k) 
-        print("unhandled ctrl_t:", 'dev_handle ==', display(dev_handle), 'and bmRequestType ==', display(bmRequestType), 'and bRequest ==', display(bRequest), 'and wValue ==', display(wValue), 'and wIndex ==', display(wIndex), 'and data_or_wLength ==', display(data_or_wLength), 'and timeout ==',timeout)
+        print('unhandled ctrl_t: bmRequestType ==', display(bmRequestType), 'and bRequest ==', display(bRequest), 'and wValue ==', display(wValue), 'and wIndex ==', display(wIndex), 'and data_or_wLength ==', display(data_or_wLength), 'and timeout ==',timeout)
 
     def read(self, endpoint, msgLen, timeout):
         " Lets just spit out a spectrum ! (tho this could be EEPROM, i think, depending on last ctrl_t) "


### PR DESCRIPTION
Recent versions of Enlighten depend on responses to two new ctrl_transfer messages: request revision code and request FPGA revision. The default implementation of pyusb-virtSpec is to return None to unknown messages, causing a device failure as Enlighten tries to parse None as hex.

This change implements a basic response to those two messages, allowing Enlighten to get past the device handshake and move on to displaying mock spectra.

To test these changes (Windows) run,
```
$ scripts\bootstrap.bat activate virtspec
$ run.bat
```
.